### PR TITLE
fix getDocumentPointsize to work with "a4paper" documentclass option

### DIFF
--- a/R/deviceUtils.R
+++ b/R/deviceUtils.R
@@ -15,7 +15,7 @@ getDocumentPointsize <- function( docString ){
   # startps component of the pDevDesc structure. 
 
   # Search the document declaration for the pointsize.
-  psLocation <- regexpr( '\\d+[pt]', docString, ignore.case = T, perl = T )
+  psLocation <- regexpr( '\\<\\d+pt', docString, ignore.case = T, perl = T )
 
   # If there were no matches, regexpr() returns -1 and this
   # function returns NA.

--- a/R/deviceUtils.R
+++ b/R/deviceUtils.R
@@ -15,7 +15,7 @@ getDocumentPointsize <- function( docString ){
   # startps component of the pDevDesc structure. 
 
   # Search the document declaration for the pointsize.
-  psLocation <- regexpr( '\\<\\d+pt', docString, ignore.case = T, perl = T )
+  psLocation <- regexpr( '\\<\\d+pt\\>', docString, ignore.case = T, perl = T )
 
   # If there were no matches, regexpr() returns -1 and this
   # function returns NA.
@@ -27,7 +27,7 @@ getDocumentPointsize <- function( docString ){
 
     # Extract and return the pointsize.
     pointsize <- substr( docString, psLocation,
-      psLocation + attr( psLocation, 'match.length') - 2 )
+      psLocation + attr( psLocation, 'match.length') - 3 )
 
     return( as.numeric( pointsize ) )
 


### PR DESCRIPTION
The previous regexp would match any number that was followed by either
"p" or "t" and use this as the document point size.  This led to

```
\documentclass[a4paper]{artice}
```

being interpreted as a 4pt document.  As a result, plotted figures
wound up with grossly scaled font nodes (scale=3 or similar).

We instead want to only match digits at the beginning of a word,
followed by the string "pt".
